### PR TITLE
This commit deals with Issue #3 on your repo

### DIFF
--- a/app/views/account/invalid_cas_user.rhtml
+++ b/app/views/account/invalid_cas_user.rhtml
@@ -1,0 +1,19 @@
+
+<div id="login-form">
+
+<table>
+<tr>
+    <td align="center">
+	<!--<%= button_to l(:cas_authenticated_user_not_found_option_login_local), { :action => :login_without_cas, :back_url =>  '/'}, :method => :get %>-->
+	<%= link_to l(:cas_authenticated_user_not_found_option_login_local), { :action => :login_without_cas, :back_url =>  '/'}, :method => :get %>
+    </td>
+</tr>
+<tr>
+    <td align="center">
+	<%= link_to l(:cas_authenticated_user_not_found_option_logout_cas, :uname => session[:cas_user]), :controller => :account, :action => :logout_with_cas %>
+    </td>
+</tr>
+</table>
+
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
 # English strings go here for Rails i18n
 en:
-  cas_authenticated_user_not_found: "Username %s authenticated with CAS but not found in Redmine. Please create user in Redmine."
+  cas_authenticated_user_not_found: "Username %{uname} authenticated with CAS but not found in Redmine."
+  cas_authenticated_user_not_found_option_login_local: "Log in locally"
+  cas_authenticated_user_not_found_option_logout_cas: "Change CAS user (Log out %{uname})"
   login_without_cas: "Sign in without CAS"


### PR DESCRIPTION
Use Case:
- CAS login enabled
- CAS auto_create_users disabled
- login_required site setting enabled
- User logged into CAS as a user that is not in Redmine

The conditions above caused an eternal loop:
- CAS check detects valid TGT but login fails, redirecting the user
  to home page, which is protected so redirects to CAS check etc.

Implemented Fix:
- Created account/invalid_cas_user view with options to:
  - Login locally or
  - Logout and return to CAS server to login as valid user.
- Modified logout behavior to prevent CAS logout if the user chose
  the first option and logged in locally. In this case, the user is
  redirected to the invalid_cas_user view (inherant behavior)
- Added strings used in the fix to en locale file (and tidied up
  the ones that were already there.

NOTE:
I am using i18n v0.5.0 so vars in en.yml use its formatting. If
you're using an older version, you would need to replace
${some var} entries with {{some var}}

```
new file:   app/views/account/invalid_cas_user.rhtml
modified:   config/locales/en.yml
modified:   lib/redmine_cas.rb
```
